### PR TITLE
Fixes for usermod

### DIFF
--- a/libraries/solaris.rb
+++ b/libraries/solaris.rb
@@ -9,32 +9,30 @@ class Chef
           unlock_user
         end
 
-        private
+        def check_lock
+          lock_check = Mixlib::ShellOut.new("passwd -s #{@new_resource.username}")
+          lock_check.run_command
 
-          def check_lock
-            lock_check = Mixlib::ShellOut.new("passwd -s #{@new_resource.username}")
-            lock_check.run_command
-
-            if lock_check.exitstatus != 0
-              raise Chef::Exceptions::User, "Cannot determine if #{@new_resource} is locked!"
-            end
-
-            username, status = lock_check.stdout.split(' ')
-
-            status == "LK"
+          if lock_check.exitstatus != 0
+            raise Chef::Exceptions::User, "Cannot determine if #{@new_resource} is locked!"
           end
 
-          def lock_user
-            unless check_lock
-              run_command(:command => "passwd -l #{@new_resource.username}")
-            end
-          end
+          username, status = lock_check.stdout.split(' ')
 
-          def unlock_user
-            if check_lock
-              run_command(:command => "passwd -u #{@new_resource.username}")
-            end
+          status == "LK"
+        end
+
+        def lock_user
+          unless check_lock
+            run_command(:command => "passwd -l #{@new_resource.username}")
           end
+        end
+
+        def unlock_user
+          if check_lock
+            run_command(:command => "passwd -u #{@new_resource.username}")
+          end
+        end
       end
     end
   end

--- a/libraries/solaris.rb
+++ b/libraries/solaris.rb
@@ -1,0 +1,41 @@
+
+class Chef
+  class Provider
+    class User
+      class Solaris < Chef::Provider::User::Useradd
+        def create
+          super
+          manage_password
+          unlock_user
+        end
+
+        private
+
+          def check_lock
+            lock_check = Mixlib::ShellOut.new("passwd -s #{@new_resource.username}")
+            lock_check.run_command
+
+            if lock_check.exitstatus != 0
+              raise Chef::Exceptions::User, "Cannot determine if #{@new_resource} is locked!"
+            end
+
+            username, status = lock_check.stdout.split(' ')
+
+            status == "LK"
+          end
+
+          def lock_user
+            unless check_lock
+              run_command(:command => "passwd -l #{@new_resource.username}")
+            end
+          end
+
+          def unlock_user
+            if check_lock
+              run_command(:command => "passwd -u #{@new_resource.username}")
+            end
+          end
+      end
+    end
+  end
+end

--- a/libraries/useradd.rb
+++ b/libraries/useradd.rb
@@ -2,7 +2,22 @@ class Chef
   class Provider
     class User 
       class Useradd < Chef::Provider::User
-        
+
+        def compare_user
+          changed = []
+          changed << [ :comment, :home, :shell, :password ].keep_if do |user_attrib|
+            !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib) != @current_resource.send(user_attrib)
+          end
+
+          changed << [ :uid, :gid ].keep_if do |user_attrib|
+            !@new_resource.send(user_attrib).nil? && @new_resource.send(user_attrib).to_i != @current_resource.send(user_attrib).to_i
+          end
+
+          changed.flatten!.any?
+        end
+
+        private
+
         def check_lock
           case node[:platform]
           when "smartos"
@@ -51,11 +66,11 @@ class Chef
 
           @locked
         end
-        
+
         def lock_user
           run_command(:command => "usermod -L #{@new_resource.username}")
         end
-        
+
         def unlock_user
           case node[:platform]
           when "smartos"


### PR DESCRIPTION
This is two things. 

First, if you send uid as a String into the user provider, chef would think the user was different every chef run and execute usermod every time. This sucks, because if you're logged in as a user managed by chef and it runs usermod on you, the command will ASPLODE with a big fat exitstatus of 8. Suck! I'm going to send a better fix into chef master, but in the meantime patching it in this bookcook is extremely convenient.

Also, in chef master smartos is changed to run Chef::Provider::User::Solaris instead of Useradd. I'm adding a class with fixes to user locking/unlocking in preparation for that, though hopefully I'll get it fixed in master before the next release.
